### PR TITLE
removed un-nessesary tabs permission to reupload to chrome webstore

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   },
   
   "permissions": [
-    "tabs", "storage"
+    "storage"
   ],
   "action": {
     "default_popup": "options.html"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dalle-prompt-helper-extension",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,4 +1,3 @@
-// find .image-prompt-form
 import {runtime, storage} from 'webextension-polyfill';
 import { sendMessage, onMessage } from 'webext-bridge'; 
 import '/src/themeHandler.js';
@@ -260,7 +259,6 @@ let injectDownloadButton = async function () {
       signature.src = (result.watermark !== 'exclude') ? url : '';
     });
     
-    zip.file("signature.png", signature.src);
     for (let i = 0; i < images.length; i++) {
       let img = images[i];
       let canvas = document.createElement("canvas");


### PR DESCRIPTION
Just got a rejection from chrome webstore that I'm not using the tabs permission. I needed it before for tab messaging but I managed to use the storage as a defacto message bus. 